### PR TITLE
Non-NT platform specific fix-ups

### DIFF
--- a/bin/bitfloor_client.py
+++ b/bin/bitfloor_client.py
@@ -17,7 +17,9 @@ import traceback
 import logging
 import sys
 import socket
-import winsound
+import os
+if os.name == 'nt': 
+  import winsound
 
 bitfloor = bitfloorapi.Client()
 
@@ -156,8 +158,11 @@ class Shell(cmd.Cmd):
                     last = D(bitfloor.ticker()['price'])
                     print '\nBalance: %s BTC + $%.2f USD = $%.2f @ $%.2f (Last)' % (btcnew,usdnew,(btcnew*last)+usdnew,last)
                     for x in xrange(0,3):
-                        winsound.Beep(1200,1000)
-                        winsound.Beep(1800,1000)
+                        if os.name == 'nt':
+                          winsound.Beep(1200,1000)
+                          winsound.Beep(1800,1000)
+                        else:
+                          print '\a\a'
                     btc,usd = btcnew,usdnew
                 notifier_stop.wait(30)
         try:

--- a/bin/encrypt_apikey.py
+++ b/bin/encrypt_apikey.py
@@ -36,7 +36,10 @@ def lock():
     salt = os.urandom(32)                   #requires Python 2.4  = 32 bytes or 256 bits of randomness
     """salt = hashlib.sha512(pre_salt).digest()    #hashing does not add any new randomness """
     fullpath = os.path.dirname(os.path.realpath(__file__))
-    partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+    if os.name == 'nt':
+      partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+    else:
+      partialpath=os.path.join(fullpath + '/../keys/' + site)
     f = open(os.path.join(partialpath + '_salt.txt'),'w')
     f.write(salt)
     f.close()

--- a/lib/unlock_api_key.py
+++ b/lib/unlock_api_key.py
@@ -18,7 +18,10 @@ def unlock(site,enc_password=""):
 
         try:
             fullpath = os.path.dirname(os.path.realpath(__file__))
-            partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+            if os.name == 'nt':
+              partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+            else:
+              partialpath=os.path.join(fullpath + '/../keys/' + site)
             f = open(os.path.join(partialpath + '_salt.txt'),'r')
             salt = f.read()
             f.close()


### PR DESCRIPTION
- Use console print '\a' instead of winsound on non-NT platforms.
- Fix directory separators on partialpath in apikey code.
