### PR TITLE
more platform fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pyinstaller.bat
 bin/*.xml
 bin/*.ini
 bin/*.txt
-bin/*.log
+*.log
 bin/test/*
 _build/*
 _static/*

--- a/bin/bcfeed_synch.py
+++ b/bin/bcfeed_synch.py
@@ -24,7 +24,10 @@ auto_move_output = 1
 begintiming = time.time()
 
 fullpath = os.path.dirname(os.path.realpath(__file__))
-partialpath=os.path.join(fullpath + '\\..\\data\\')
+if os.name == 'nt':
+  partialpath=os.path.join(fullpath + '\\..\\data\\')
+else:
+  partialpath=os.path.join(fullpath + '/../data/')
 
 try:
     for line in open(os.path.join(partialpath + 'download_mtgoxUSD.csv')):pass

--- a/bin/bitfloor_client.py
+++ b/bin/bitfloor_client.py
@@ -17,7 +17,9 @@ import traceback
 import logging
 import sys
 import socket
-import winsound
+import os
+if os.name == 'nt': 
+  import winsound
 
 bitfloor = bitfloorapi.Client()
 
@@ -156,8 +158,11 @@ class Shell(cmd.Cmd):
                     last = D(bitfloor.ticker()['price'])
                     print '\nBalance: %s BTC + $%.2f USD = $%.2f @ $%.2f (Last)' % (btcnew,usdnew,(btcnew*last)+usdnew,last)
                     for x in xrange(0,3):
-                        winsound.Beep(1200,1000)
-                        winsound.Beep(1800,1000)
+                        if os.name == 'nt':
+                          winsound.Beep(1200,1000)
+                          winsound.Beep(1800,1000)
+                        else:
+                          print '\a\a'
                     btc,usd = btcnew,usdnew
                 notifier_stop.wait(30)
         try:

--- a/bin/bitstamp_client.py
+++ b/bin/bitstamp_client.py
@@ -16,7 +16,8 @@ import traceback
 import logging
 import sys
 import socket
-import winsound
+if os.name == 'nt':
+  import winsound
 
 #################################
 
@@ -182,8 +183,11 @@ class Shell(cmd.Cmd):
                     last = D(bitstamp.ticker()['last'])
                     print '\nBalance: %s BTC + $%s USD = $%.5f @ $%.5f (Last)' % (btcnew,usdnew,(btcnew*last)+usdnew,last)
                     for x in xrange(0,3):
-                        winsound.Beep(1200,1000)
-                        winsound.Beep(1800,1000)
+                        if os.name == 'nt':
+                          winsound.Beep(1200,1000)
+                          winsound.Beep(1800,1000)
+                        else:
+                          print '\a\a'
                     btc,usd = btcnew,usdnew
                 notifier_stop.wait(30)
 

--- a/bin/btcerates.py
+++ b/bin/btcerates.py
@@ -5,16 +5,16 @@ import json
 import hashlib
 import hmac
 import time
-import winsound
 import os
-
-
 import unlock_api_key 
-
-
+if os.name == 'nt':
+  import winsound
 
 fullpath = os.path.dirname(os.path.realpath(__file__))
-partialpath=os.path.join(fullpath + '\\..\\data\\')
+if os.name == 'nt':
+  partialpath=os.path.join(fullpath + '\\..\\data\\')
+else:
+  partialpath=os.path.join(fullpath + '/../data/')
 BTC_api_key,BTC_api_secret,unused = unlock_api_key.unlock("btc-e") 
 
 #you must have a nonce_state_btce file located in your ..\data\ directory with an integer number inside the file  
@@ -203,8 +203,11 @@ def ac_auto(x):
             print
             if new_tot!=tot:
                 tot=new_tot
-                winsound.Beep(1000,300)
-                winsound.Beep(500,300)
+                if os.name == 'nt':
+                  winsound.Beep(1000,300)
+                  winsound.Beep(500,300)
+                else:
+                  print '\a\a'
             time.sleep(x)               
         except KeyboardInterrupt:
             print 'Canceled by user'

--- a/bin/encrypt_apikey.py
+++ b/bin/encrypt_apikey.py
@@ -36,7 +36,10 @@ def lock():
     salt = os.urandom(32)                   #requires Python 2.4  = 32 bytes or 256 bits of randomness
     """salt = hashlib.sha512(pre_salt).digest()    #hashing does not add any new randomness """
     fullpath = os.path.dirname(os.path.realpath(__file__))
-    partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+    if os.name == 'nt':
+      partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+    else:
+      partialpath=os.path.join(fullpath + '/../keys/' + site)
     f = open(os.path.join(partialpath + '_salt.txt'),'w')
     f.write(salt)
     f.close()

--- a/bin/mtgox_client.py
+++ b/bin/mtgox_client.py
@@ -9,7 +9,6 @@ import cmd
 import time
 import json
 import traceback
-import winsound         #plays beeps for alerts 
 import threading        #for subthreads
 import datetime
 from decimal import Decimal as D    #renamed to D for simplicity.
@@ -22,6 +21,8 @@ from common import *
 import depthparser
 import mtgox_prof7bitapi
 import mtgoxhmac
+if os.name == 'nt':
+  import winsound       #plays beeps for alerts
 
 mtgox = mtgoxhmac.Client()
 
@@ -73,7 +74,10 @@ print "Finished."
 
 # data partial path directory
 fullpath = os.path.dirname(os.path.realpath(__file__))
-partialpath=os.path.join(fullpath + '\\..\\data\\')
+if os.name == 'nt':
+  partialpath=os.path.join(fullpath + '\\..\\data\\')
+else:
+  partialpath=os.path.join(fullpath + '/../data/')
 
 """
 def decideto():
@@ -275,8 +279,11 @@ class Shell(cmd.Cmd):
                     last = D(str(mtgox.get_ticker()['last']))
                     print '\nBalance: %s BTC + $%s USD = $%.5f @ $%.5f (Last)' % (btcnew,usdnew,(btcnew*last)+usdnew,last)
                     for x in xrange(0,3):
-                        winsound.Beep(1200,1000)
-                        winsound.Beep(1800,1000)
+                        if os.name == 'nt':
+                          winsound.Beep(1200,1000)
+                          winsound.Beep(1800,1000)
+                        else:
+                          print '\a\a'
                     btc,usd = btcnew,usdnew
                 notifier_stop.wait(30)
 
@@ -866,7 +873,10 @@ class Shell(cmd.Cmd):
                     elif last >= high:
                         print "ALERT!! Ticker has risen above range %s-%s. Price is now: %s" % (low,high,last)
                         for x in range(2,25):
-                            winsound.Beep(x*100,90)  #frequency(Hz),duration(ms)
+                            if os.name == 'nt':
+                              winsound.Beep(x*100,90)  #frequency(Hz),duration(ms)
+                            else:
+                              print '\a'
                         low = high - 0.5
                         high = low + 3
                         #decideto()
@@ -878,7 +888,10 @@ class Shell(cmd.Cmd):
                     else:
                         print "ALERT!! Ticker has fallen below range %s-%s. Price is now: %s" % (low,high,last)
                         for x in range(25,2,-1):
-                            winsound.Beep(x*100,90)
+                            if os.name == 'nt':
+                              winsound.Beep(x*100,90)
+                            else:
+                              print '\a'
                         high = low + 1
                         low = high -3
                         #decideto()

--- a/lib/btceapi.py
+++ b/lib/btceapi.py
@@ -27,7 +27,10 @@ class Client:
     #must already have this nonce file in ..\data\
     def nonce_generator(self):
         fullpath = os.path.dirname(os.path.realpath(__file__))
-        partialpath=os.path.join(fullpath + '\\..\\data\\')
+        if os.name == 'nt':
+          partialpath=os.path.join(fullpath + '\\..\\data\\')
+        else:
+          partialpath=os.path.join(fullpath + '/../data/')
 
         fd = open(os.path.join(partialpath + 'nonce_state_btce'),'r')
         nonce = int(fd.read())

--- a/lib/common.py
+++ b/lib/common.py
@@ -29,7 +29,10 @@ class ServerError(Exception):
 
         
 fullpath = os.path.dirname(os.path.realpath(__file__))
-partialpath=os.path.join(fullpath + '\\..\\data\\')
+if os.path == 'nt':
+  partialpath=os.path.join(fullpath + '\\..\\data\\')
+else:
+  partialpath=os.path.join(fullpath + '/../data/')
 
 #write the FULL depth to a log file
 def writedepth(mtgox):

--- a/lib/tradehistory.py
+++ b/lib/tradehistory.py
@@ -12,7 +12,10 @@ import datetime
 import math
 
 fullpath = os.path.dirname(os.path.realpath(__file__))
-partialpath=os.path.join(fullpath + '\\..\\data\\')
+if os.name == 'nt':
+  partialpath=os.path.join(fullpath + '\\..\\data\\')
+else:
+  partialpath=os.path.join(fullpath + '/../data/')
 
 #all it does is a simple "mean" calculation
 def movavg(trades):

--- a/lib/unlock_api_key.py
+++ b/lib/unlock_api_key.py
@@ -18,7 +18,10 @@ def unlock(site,enc_password=""):
 
         try:
             fullpath = os.path.dirname(os.path.realpath(__file__))
-            partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+            if os.name == 'nt':
+              partialpath=os.path.join(fullpath + '\\..\\keys\\' + site)
+            else:
+              partialpath=os.path.join(fullpath + '/../keys/' + site)
             f = open(os.path.join(partialpath + '_salt.txt'),'r')
             salt = f.read()
             f.close()


### PR DESCRIPTION
73232bb - more platform fixups
- Use system bell '\a' on non-NT systems, instead of winsound
- Use '/' directory separators, instead of '\' on non-NT platforms
- Ignore *.log files everywhere, not just in bin
